### PR TITLE
Fix: Correct argument order for workflow import subject and description templates

### DIFF
--- a/conductor-server/src/main/java/io/appform/conductor/server/workflowmanagement/WorkflowManager.java
+++ b/conductor-server/src/main/java/io/appform/conductor/server/workflowmanagement/WorkflowManager.java
@@ -16,7 +16,6 @@
 
 package io.appform.conductor.server.workflowmanagement;
 
-import com.google.common.collect.Sets;
 import io.appform.conductor.model.actions.Action;
 import io.appform.conductor.model.actions.Scope;
 import io.appform.conductor.model.error.ConductorErrorCode;
@@ -538,8 +537,8 @@ public class WorkflowManager {
                                                inWorkflow.getDescription(),
                                                inWorkflow.getSchemaId(),
                                                inWorkflow.getTitleTemplate(),
-                                               inWorkflow.getSubjectIdTemplate(),
-                                               inWorkflow.getDescriptionTemplate())
+                                               inWorkflow.getDescriptionTemplate(),
+                                               inWorkflow.getSubjectIdTemplate())
                         .flatMap(wf -> workflowStore.update(wf.getId(),
                                                             existing -> existing.setStartStateId(inWorkflow.getStartStateId()))))
                 .map(workflow -> {
@@ -564,7 +563,7 @@ public class WorkflowManager {
                                                                                                      transition.getType(),
                                                                                                      transition.getRule(),
                                                                                                      transition.getActionIds())));
-                    return inWorkflow;
+                    return workflow;
                 })
                 .map(workflow -> new ImportResult<>(workflow, true, null))
                 .orElse(new ImportResult<>(inWorkflow, false, ConductorErrorCode.STORE_WRITE_ERROR.name()));

--- a/conductor-server/src/test/java/io/appform/conductor/server/workflowmanagement/WorkflowManagerTest.java
+++ b/conductor-server/src/test/java/io/appform/conductor/server/workflowmanagement/WorkflowManagerTest.java
@@ -150,6 +150,8 @@ class WorkflowManagerTest {
                             .anyMatch(actionImportResult -> !actionImportResult.isSuccess()));
         assertFalse(result.getActions().stream()
                             .anyMatch(actionImportResult -> !actionImportResult.isSuccess()));
+        assertEquals("Subject", result.getWorkflow().getData().getSubjectIdTemplate().getTemplate());
+        assertEquals("Description", result.getWorkflow().getData().getDescriptionTemplate().getTemplate());
 
         {
             val idempotentResult = wfm.importWorkflow(workflowDetails, false, false);
@@ -159,6 +161,8 @@ class WorkflowManagerTest {
                                 .noneMatch(ImportResult::isSuccess)); //Actions can't be overwritten
             assertTrue(idempotentResult.getTasks().stream()
                                 .noneMatch(ImportResult::isSuccess)); //Tasks can't be overwritten
+            assertEquals("Subject", idempotentResult.getWorkflow().getData().getSubjectIdTemplate().getTemplate());
+            assertEquals("Description", idempotentResult.getWorkflow().getData().getDescriptionTemplate().getTemplate());
         }
         {
             val idempotentResult = wfm.importWorkflow(workflowDetails, true, true);

--- a/conductor-server/src/test/resources/fixtures/workflow_details.json
+++ b/conductor-server/src/test/resources/fixtures/workflow_details.json
@@ -4,6 +4,14 @@
     "displayName" : "TestWorkflow",
     "description" : "Description",
     "schemaId" : "testingschema",
+    "descriptionTemplate" : {
+      "type" : "FIXED",
+      "template" : "Description"
+    },
+    "subjectIdTemplate" : {
+       "type" : "FIXED",
+      "template" : "Subject"
+    },
     "states" : {
       "TESTWORKFLOW_FIRST_STATE" : {
         "id" : "TESTWORKFLOW_FIRST_STATE",


### PR DESCRIPTION
### Issue
When importing workflows, the `subjectIdTemplate` and `descriptionTemplate` arguments were being passed in the wrong order to the workflow builder, causing these templates to be swapped during the import process.

### Changes Made

**Fixed argument order in `WorkflowManager.java`**
- Swapped the order of `descriptionTemplate` and `subjectIdTemplate` parameters

**Fixed return value in import logic [Please review if this is correct]**
- Corrected the return statement to return the properly configured `workflow` object instead of `inWorkflow`
- This ensures the workflow returned includes all the updates from the import operation

**Removed unused import**
- Removed unused `com.google.common.collect.Sets` import

**Added test assertions**
- Subject ID and Description templates are correctly set to "Subject"
- Tests cover both initial import and idempotent import scenarios

**Updated test fixture**
- Added `descriptionTemplate` and `subjectIdTemplate` fields to `workflow_details.json` fixture to properly test the scenario

### Testing
All existing tests pass and tested the import feature locally.