### PR TITLE
Enhance template evaluators

### DIFF
--- a/conductor-server/src/main/java/io/appform/conductor/server/resources/ui/Manage.java
+++ b/conductor-server/src/main/java/io/appform/conductor/server/resources/ui/Manage.java
@@ -438,7 +438,7 @@ public class Manage {
         return workflowManager.updateTemplates(workflowId,
                                                template(titleTemplate),
                                                template(descriptionTemplate),
-                                               template(subjectTemplate))
+                                               templateHandlebars(subjectTemplate))
                 .map(wf -> redirect("/manage/workflow/" + wf.getId()))
                 .orElseThrow(() -> fail("Failed to update workflow " + workflowId, "/manage/workflow"));
     }
@@ -1021,6 +1021,12 @@ public class Manage {
     private static io.appform.conductor.model.workflow.Template template(String templateValue) {
         return new io.appform.conductor.model.workflow.Template(io.appform.conductor.model.workflow.Template.Type.STRING_SUBSTITUTION,
                                                                 templateValue);
+    }
+
+
+    private static io.appform.conductor.model.workflow.Template templateHandlebars(String templateValue) {
+        return new io.appform.conductor.model.workflow.Template(io.appform.conductor.model.workflow.Template.Type.HANDLEBARS,
+                templateValue);
     }
 
     private static Rule createAssignmentRule(GroupType type, List<String> skillValueId) {

--- a/conductor-server/src/main/java/io/appform/conductor/server/templateengines/HandlebarsObjectTemplateEvaluator.java
+++ b/conductor-server/src/main/java/io/appform/conductor/server/templateengines/HandlebarsObjectTemplateEvaluator.java
@@ -20,9 +20,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.appform.conductor.model.workflow.Template;
+import io.appform.conductor.server.utils.HandlebarsUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import org.apache.commons.text.StringSubstitutor;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -34,13 +34,21 @@ import java.util.Optional;
  */
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = {@Inject})
-public class StringSubstitutionTextTemplateEvaluator implements TextTemplateEvaluator {
+public class HandlebarsObjectTemplateEvaluator implements ObjectTemplateEvaluator {
     private final ObjectMapper mapper;
 
     @Override
     @SneakyThrows
-    public Optional<String> evaluate(Template template, JsonNode payload) {
-        return Optional.of(StringSubstitutor.replace(
-                template.getTemplate(), mapper.convertValue(payload, new TypeReference<Map<String, Object>>() {})));
+    public <T> Optional<T> evaluate(Template template, JsonNode payload, Class<T> clazz) {
+        return Optional.of(HandlebarsUtils.handlebars().compileInline(template.getTemplate())
+                        .apply(mapper.convertValue(payload, new TypeReference<Map<String, Object>>() {
+                        })))
+                .map(s -> {
+                    try {
+                        return mapper.readValue(s, clazz);
+                    } catch (Exception e) {
+                        throw new RuntimeException("Failed to parse substituted string to object", e);
+                    }
+                });
     }
 }

--- a/conductor-server/src/main/java/io/appform/conductor/server/templateengines/TemplateEngine.java
+++ b/conductor-server/src/main/java/io/appform/conductor/server/templateengines/TemplateEngine.java
@@ -40,11 +40,13 @@ public class TemplateEngine {
             FixedTextTemplateEvaluator fixedTextTemplateEvaluator,
             StringSubstitutionTextTemplateEvaluator stringSubstitutionTemplateEvaluator,
             HandlebarsTextTemplateEvaluator handlebarsTextTemplateEvaluator,
-            FixedObjectTemplateEvaluator fixedObjectTemplateEvaluator) {
+            FixedObjectTemplateEvaluator fixedObjectTemplateEvaluator,
+            HandlebarsObjectTemplateEvaluator handlebarsObjectTemplateEvaluator) {
         textEvaluators = Map.of(Template.Type.FIXED, fixedTextTemplateEvaluator,
                                   Template.Type.STRING_SUBSTITUTION, stringSubstitutionTemplateEvaluator,
                                   Template.Type.HANDLEBARS, handlebarsTextTemplateEvaluator);
-        objectEvaluators = Map.of(Template.Type.FIXED, fixedObjectTemplateEvaluator);
+        objectEvaluators = Map.of(Template.Type.FIXED, fixedObjectTemplateEvaluator,
+                Template.Type.HANDLEBARS, handlebarsObjectTemplateEvaluator);
     }
 
 

--- a/conductor-server/src/main/java/io/appform/conductor/server/ui/CustomHelpers.java
+++ b/conductor-server/src/main/java/io/appform/conductor/server/ui/CustomHelpers.java
@@ -705,6 +705,30 @@ public class CustomHelpers {
         return "";
     }
 
+    /**
+     * Extract a String value from a JSON object using a JSON Pointer path.
+     * Converts the context object to a JsonNode and navigates using the pointer parameter.
+     * 
+     * Usage: {{valueFromJson pointer='/message/0/id'}}
+     * 
+     * @param context the object to convert to JSON
+     * @param options Handlebars options containing the 'pointer' parameter with JSON Pointer path
+     * @return the string value at the pointer location, or empty string if not found or null
+     */
+    @SneakyThrows
+    public String valueFromJson(Object context, Options options) {
+        val node = MAPPER.valueToTree(context);
+        val pointer = (String) options.hash(POINTER);
+        if (!Strings.isNullOrEmpty(pointer) ) {
+            val valueNode = node.at(pointer);
+            if (Objects.isNull(valueNode) || valueNode.isNull()) {
+                return "";
+            }
+            return valueNode.asText();
+        }
+        return "";
+    }
+
     public long toIntPtr(Object context, Options options) {
         val node = MAPPER.valueToTree(context);
         final String pointer = options.hash(POINTER);

--- a/conductor-server/src/test/java/io/appform/conductor/server/actionmanagement/executors/WebhookActionExecutorTest.java
+++ b/conductor-server/src/test/java/io/appform/conductor/server/actionmanagement/executors/WebhookActionExecutorTest.java
@@ -40,7 +40,8 @@ public class WebhookActionExecutorTest {
         val templateEngine = new TemplateEngine(new FixedTextTemplateEvaluator(),
                 new StringSubstitutionTextTemplateEvaluator(mapper),
                 new HandlebarsTextTemplateEvaluator(mapper),
-                new FixedObjectTemplateEvaluator(mapper));
+                new FixedObjectTemplateEvaluator(mapper),
+                new HandlebarsObjectTemplateEvaluator(mapper));
         val httpClient = ConductorServerUtils.createHttpClient();
         //create webhookActionExecutor
         WebhookActionExecutor webhookActionExecutor = new WebhookActionExecutor(templateEngine, httpClient, mapper);
@@ -79,7 +80,8 @@ public class WebhookActionExecutorTest {
         val templateEngine = new TemplateEngine(new FixedTextTemplateEvaluator(),
                 new StringSubstitutionTextTemplateEvaluator(mapper),
                 new HandlebarsTextTemplateEvaluator(mapper),
-                new FixedObjectTemplateEvaluator(mapper));
+                new FixedObjectTemplateEvaluator(mapper),
+                new HandlebarsObjectTemplateEvaluator(mapper));
         val httpClient = ConductorServerUtils.createHttpClient();
         //create webhookActionExecutor
         WebhookActionExecutor webhookActionExecutor = new WebhookActionExecutor(templateEngine, httpClient, mapper);

--- a/conductor-server/src/test/java/io/appform/conductor/server/templateengines/HandlebarsTextTemplateEvaluatorTest.java
+++ b/conductor-server/src/test/java/io/appform/conductor/server/templateengines/HandlebarsTextTemplateEvaluatorTest.java
@@ -955,6 +955,20 @@ public class HandlebarsTextTemplateEvaluatorTest {
     }
 
     @Test
+    public void testValueFromJson() {
+        val mapper = Jackson.newObjectMapper();
+
+        val node = mapper.createObjectNode()
+                .set("message", mapper.createArrayNode().add(mapper.createObjectNode().set("id", TextNode.valueOf("893649f5-9cf9-4422-87d1-a9c4258045e7"))));
+
+        val transformed = handlebarTextTemplateEvaluator.evaluate(new Template(Template.Type.HANDLEBARS, "{{valueFromJson pointer='/message/0/id'}}"), node).get();
+        assertEquals("893649f5-9cf9-4422-87d1-a9c4258045e7", transformed);
+
+        val incorrectPointer = handlebarTextTemplateEvaluator.evaluate(new Template(Template.Type.HANDLEBARS, "{{valueFromJson pointer='/message/1/id'}}"), node).get();
+        assertEquals("", incorrectPointer);
+    }
+
+    @Test
     public void testStringEqualsIgnoreCase() {
 
 

--- a/conductor-server/src/test/java/io/appform/conductor/server/templateengines/StringSubstitutionTextTemplateEvaluatorTest.java
+++ b/conductor-server/src/test/java/io/appform/conductor/server/templateengines/StringSubstitutionTextTemplateEvaluatorTest.java
@@ -1,0 +1,67 @@
+package io.appform.conductor.server.templateengines;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.appform.conductor.model.workflow.Template;
+import io.dropwizard.jackson.Jackson;
+import org.junit.jupiter.api.Test;
+
+public class StringSubstitutionTextTemplateEvaluatorTest {
+
+    private ObjectMapper mapper = Jackson.newObjectMapper();
+
+    private StringSubstitutionTextTemplateEvaluator evaluator = new StringSubstitutionTextTemplateEvaluator(mapper);
+
+    @Test
+    public void testEvaluate() throws JsonProcessingException {
+        String templateStr = "Hello ${name}, your age is ${age}";
+        Template template = new Template(Template.Type.STRING_SUBSTITUTION, templateStr);
+        JsonNode payload =  mapper.readTree("""
+                {
+                    "name": "Alice",
+                    "age": 30,
+                    "place": {
+                        "name": "Wonderland",
+                        "city": "Fictional City"
+                     }
+                }
+                """);
+        String result = evaluator.evaluate(template, payload).orElse(null);
+        assert result != null;
+        assert result.equals("Hello Alice, your age is 30");
+    }
+
+    @Test
+    public void testEvaluateWithMissingVariable() throws JsonProcessingException {
+        String templateStr = "Hello ${name}, your age is ${age}, you live in ${place.name}";
+        Template template = new Template(Template.Type.STRING_SUBSTITUTION, templateStr);
+        JsonNode payload =  mapper.readTree("""
+                {
+                    "name": "Alice",
+                    "age": 30
+                }
+                """);
+        String result = evaluator.evaluate(template, payload).orElse(null);
+        assert result != null;
+        assert result.equals("Hello Alice, your age is 30, you live in ${place.name}");
+    }
+
+    @Test
+    public void testEvaluateWithNestedVariableIgnored() throws JsonProcessingException {
+        String templateStr = "Hello ${name}, your age is ${age}, you live in ${place.name}";
+        Template template = new Template(Template.Type.STRING_SUBSTITUTION, templateStr);
+        JsonNode payload =  mapper.readTree("""
+                {
+                    "name": "Alice",
+                    "age": 30,
+                    "place": {
+                        "name": "Wonderland"
+                     }
+                }
+                """);
+        String result = evaluator.evaluate(template, payload).orElse(null);
+        assert result != null;
+        assert result.equals("Hello Alice, your age is 30, you live in ${place.name}");
+    }
+}

--- a/conductor-server/src/test/java/io/appform/conductor/server/ticketmanagement/TicketManagerTest.java
+++ b/conductor-server/src/test/java/io/appform/conductor/server/ticketmanagement/TicketManagerTest.java
@@ -157,7 +157,8 @@ class TicketManagerTest {
         val te = new TemplateEngine(new FixedTextTemplateEvaluator(),
                                     new StringSubstitutionTextTemplateEvaluator(mapper),
                                     new HandlebarsTextTemplateEvaluator(mapper),
-                                    new FixedObjectTemplateEvaluator(mapper));
+                                    new FixedObjectTemplateEvaluator(mapper),
+                                    new HandlebarsObjectTemplateEvaluator(mapper));
         val workflowSelector = new WorkflowSelector(wStore, re);
         workflowSelector.start();
         val actionExecutor = mock(ActionExecutor.class);


### PR DESCRIPTION
This pull request introduces enhancements to the template engine system to support additional template evaluation capabilities and improve type handling.

### Changes

#### Bug fix and features
- **Handlebars Object Template Evaluator**: Added `HandlebarsObjectTemplateEvaluator` to support Handlebars template evaluation to return object type. The existing evaluator returned String and subjectId template expected an object (bug).
- **Custom Helper for JSON Value Extraction**: Implemented `valueFromJson()` helper method in `CustomHelpers` to extract string values from JSON objects. The existing `valueFromJsonString` method expects String input rather than JsonNode.

#### Improvements
- **Type Handling**: Updated `StringSubstitutionTextTemplateEvaluator` to use `Map<String, Object>` instead of `Map<String, String>` to support nested json payload. The existing implementation was breaking with nested payloads.
- **Workflow Management**: Updated subject templates to use handlebars instead of string-replacement.

#### Test Coverage
- added tests for the changes.